### PR TITLE
fix(logger): remove process.exit from fatal to avoid killing extension

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,7 +4,6 @@
  * @date 2024-11-13
  */
 
-import { exit } from "process";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
@@ -164,7 +163,6 @@ export namespace logger {
       logMessage(LOG_LEVELS_SLUG.FATAL, ...args);
       vscode.window.showErrorMessage(args.join(" "));
     }
-    exit(1);
   }
 
   /**


### PR DESCRIPTION
This PR fixes a complete IDE closing bug that happened when users encountered a fatal error from logger (on logger setup).

Fixes #55 