### PR TITLE
fix(logger): stop error() from always popping a modal toast

### DIFF
--- a/src/database/model/model.ts
+++ b/src/database/model/model.ts
@@ -96,7 +96,12 @@ export namespace db_model {
 
       logger.debug("Database initialized successfully");
     } catch (err) {
-      logger.error(`Failed to initialize database: ${(err as Error).message}`);
+      // Fatal for the extension's core functionality and not otherwise
+      // surfaced to the user (the caller re-throws without its own UI),
+      // so this is one of the rare cases worth an explicit notification.
+      logger.showError(
+        `Achievements: Failed to initialize database: ${(err as Error).message}`,
+      );
       throw err;
     }
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -135,7 +135,9 @@ export namespace logger {
   }
 
   /**
-   * Logs an error message (if log level allows)
+   * Logs an error message (if log level allows). Does not surface a UI
+   * notification: most errors logged this way are internal failures the
+   * user cannot act on. Use `showError` for the rare user-actionable case.
    *
    * @memberof logger
    * @function error
@@ -146,6 +148,25 @@ export namespace logger {
   export function error(...args: unknown[]) {
     if (logLevel <= LOG_LEVELS.ERROR) {
       logMessage(LOG_LEVELS_SLUG.ERROR, ...args);
+    }
+  }
+
+  /**
+   * Logs an error message and, if notifications are enabled, surfaces it as
+   * an error notification. Reserve this for errors the user genuinely needs
+   * to see and can act on.
+   *
+   * @memberof logger
+   * @function showError
+   *
+   * @param {any[]} args - The message to log and display
+   * @returns void
+   */
+  export function showError(...args: unknown[]) {
+    if (logLevel <= LOG_LEVELS.ERROR) {
+      logMessage(LOG_LEVELS_SLUG.ERROR, ...args);
+    }
+    if (config.notificationsEnabled()) {
       vscode.window.showErrorMessage(args.join(" "));
     }
   }


### PR DESCRIPTION
This PR updates the behavior of the logger "error" method.

Now "error" only logs the error, and a new "showError" method was added to display errors that should be seen by the user.

Fixes #57 