### PR TITLE
fix(listeners): dispose onDidChangeBreakpoints and batch progression update

### DIFF
--- a/src/listeners/debug.ts
+++ b/src/listeners/debug.ts
@@ -40,12 +40,15 @@ export namespace debugListeners {
 
       vscode.debug.onDidChangeBreakpoints(
         async (event: vscode.BreakpointsChangeEvent) => {
-          for (const _ of event.added) {
+          if (event.added.length > 0) {
             await ProgressionController.increaseProgression(
               constants.criteria.BREAKPOINTS,
+              event.added.length,
             );
           }
         },
+        null,
+        context.subscriptions,
       );
 
       logger.debug("Debug listeners activated");


### PR DESCRIPTION
This PR properly registers the onDidChangeBreakpoints into the subscriptions, so it is properly disabled on extension disabling.

This also optimizes the breakpoint listener trigger processing logic.

Fixes #64 