### PR TITLE
fix(database): standardize achievedAt to ISO-8601 and harden date parsing

### DIFF
--- a/src/database/model/tables/Progression.ts
+++ b/src/database/model/tables/Progression.ts
@@ -239,18 +239,21 @@ class Progression {
         )
       )
       UPDATE achievements
-      SET achieved = TRUE, achievedAt = CURRENT_TIMESTAMP
+      SET achieved = TRUE, achievedAt = ?
       WHERE id IN (SELECT achievement_id FROM valid_achievements)
       RETURNING id, title, achievedAt, exp;
     `;
 
     const db = await db_model.getDB();
 
-    // Pass the progressionIds as parameters to the query
+    // Pass the progressionIds and the achievedAt timestamp (ISO-8601, to
+    // match the format used by the JS-side updateAchieved path) as
+    // parameters to the query, in the order their placeholders appear.
+    const achievedAt = new Date().toISOString();
     const rows = db_model.getAll(
       db,
       updateAchievementsQuery,
-      progressionIds,
+      [...progressionIds, achievedAt],
     ) as {
       id: number;
       title: string;

--- a/src/views/components/AchievementDisplay.tsx
+++ b/src/views/components/AchievementDisplay.tsx
@@ -10,10 +10,16 @@ const AchievementDisplay: React.FC<AchievementDict> = (achievementDict: Achievem
   const parseDateString = (dateValue: string | Date): string => {
     const dateString =
       typeof dateValue === 'string' ? dateValue : dateValue.toISOString();
-    const splitDate = dateString.split('T');
-    const date = splitDate[0];
-    const time = splitDate[1].split('.')[0];
-    return `${date} @${time}`;
+    // Accept both ISO-8601 ("YYYY-MM-DDTHH:MM:SS.sssZ") and SQLite's
+    // CURRENT_TIMESTAMP ("YYYY-MM-DD HH:MM:SS") formats.
+    const [date, time] = dateString.split(/[T ]/);
+    if (!date) {
+      return dateString;
+    }
+    if (!time) {
+      return date;
+    }
+    return `${date} @${time.split('.')[0]}`;
   };
 
   return (


### PR DESCRIPTION
This PR standardizes time format for achievedAt across the codebase.
There was currently a conflict between the default SQL `CURRENT_TIMESTAMP` and the one we arbitrarely decided on.
This aligns them by using only javascript one, and for backwards compatibility, the time decoding function has been adapted to support both.

Fixes #66 