### PR TITLE
perf(database): debounce full DB export/write on hot mutation paths

### DIFF
--- a/src/database/model/model.ts
+++ b/src/database/model/model.ts
@@ -24,6 +24,10 @@ let DB: Database | null = null;
 let SQL: SqlJsStatic | null = null;
 // Flag to prevent database saves during initialization
 let isInitializing = false;
+// Debounce window for scheduleSave(): coalesces bursts of mutations
+// (e.g. keystrokes) into a single full-DB export/write.
+const SAVE_DEBOUNCE_MS = 2000;
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
 // ================== MODULE FUNCTIONS ==================
 
@@ -131,6 +135,43 @@ export namespace db_model {
   }
 
   /**
+   * Schedule a database save, coalescing calls that happen within the
+   * debounce window into a single saveDB() (a full DB export + file
+   * rewrite) instead of blocking the caller on it. Prefer this over
+   * calling saveDB() directly from mutation hot paths (e.g. per-keystroke
+   * progression updates); use saveDB() directly when the write must
+   * happen immediately and be awaited (init, tests).
+   *
+   * @returns {void}
+   */
+  export function scheduleSave(): void {
+    if (saveTimer) {
+      return;
+    }
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      saveDB().catch((err: unknown) => {
+        logger.error(`Failed to run scheduled database save: ${err}`);
+      });
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  /**
+   * Cancel any pending debounced save and write the database immediately.
+   * Call this before the database connection is closed (e.g. deactivate())
+   * so a debounced mutation is never silently lost.
+   *
+   * @returns {Promise<void>}
+   */
+  export async function flushPendingSave(): Promise<void> {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    await saveDB();
+  }
+
+  /**
    * Activate the database module.
    * This function should be called when the extension is activated.
    * It will create the database file if it does not exist, and apply any necessary migrations.
@@ -192,6 +233,10 @@ export namespace db_model {
     // Reset initialization flag on deactivation
     isInitializing = false;
 
+    if (DB && !db_lock.isReadOnly()) {
+      await flushPendingSave();
+    }
+
     if (DB) {
       try {
         DB.close();
@@ -216,6 +261,10 @@ export namespace db_model {
     isInitializing = false;
     DB = null;
     SQL = null;
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
   }
 
   /**

--- a/src/database/model/tables/Achievement.ts
+++ b/src/database/model/tables/Achievement.ts
@@ -496,7 +496,7 @@ class Achievement {
       }
 
       db.run("COMMIT");
-      await db_model.saveDB();
+      db_model.scheduleSave();
     } catch (error) {
       db.run("ROLLBACK");
       throw error;
@@ -566,7 +566,7 @@ class Achievement {
     } finally {
       statement.free();
     }
-    await db_model.saveDB();
+    db_model.scheduleSave();
   }
 
   /**
@@ -597,7 +597,7 @@ class Achievement {
     } finally {
       statement.free();
     }
-    await db_model.saveDB();
+    db_model.scheduleSave();
   }
 
   // ==================== GET ====================

--- a/src/database/model/tables/DailySession.ts
+++ b/src/database/model/tables/DailySession.ts
@@ -46,7 +46,7 @@ export class DailySession {
       } finally {
         statement.free();
       }
-      await db_model.saveDB();
+      db_model.scheduleSave();
 
       // Fetch the inserted row back by its unique date, since sql.js's API
       // does not expose the RETURNING clause.
@@ -87,7 +87,7 @@ export class DailySession {
     } finally {
       statement.free();
     }
-    await db_model.saveDB();
+    db_model.scheduleSave();
     this.duration += duration;
   }
 

--- a/src/database/model/tables/Progression.ts
+++ b/src/database/model/tables/Progression.ts
@@ -147,7 +147,7 @@ class Progression {
     } finally {
       statement.free();
     }
-    await db_model.saveDB();
+    db_model.scheduleSave();
 
     // Change the id of the instance to the id of the row if it was inserted
     const idRow = db_model.get<{ id: number }>(
@@ -190,7 +190,7 @@ class Progression {
         statement.free();
       }
       db.run("COMMIT");
-      await db_model.saveDB();
+      db_model.scheduleSave();
     } catch (error) {
       db.run("ROLLBACK");
       throw error;
@@ -266,7 +266,7 @@ class Progression {
       achievedAt: string;
       exp: number;
     }[];
-    await db_model.saveDB();
+    db_model.scheduleSave();
     return rows;
   }
 
@@ -309,7 +309,7 @@ class Progression {
     ) as {
       id: number;
     }[];
-    await db_model.saveDB();
+    db_model.scheduleSave();
     return rows;
   }
 
@@ -354,7 +354,7 @@ class Progression {
       query,
       maximize ? [value, selectorValue, value] : [value, selectorValue],
     ) as { id: number }[];
-    await db_model.saveDB();
+    db_model.scheduleSave();
     return rows;
   }
 


### PR DESCRIPTION
This PR optimizes database saves to avoid burst disk writes. Database saves to disk are now delayed for up to 2 seconds to avoid writing too many unrequired saves to disk on "saves bursts" that could happen when copy pasting / other events.

Fixes #56 