### PR TITLE
perf(views): debounce search title input and drop stale query responses

### DIFF
--- a/src/database/model/tables/Achievement.ts
+++ b/src/database/model/tables/Achievement.ts
@@ -60,6 +60,9 @@ export interface AchievementSelectRequestFilters {
   sortCriteria?: string;
   sortDirection?: string;
   count?: boolean;
+  // Opaque id echoed back in the response so callers can discard stale,
+  // out-of-order responses to superseded requests.
+  requestId?: number;
 }
 // Achievement row, used to represent an achievement row from the database
 interface RawAchievementRow {

--- a/src/test/connection-streak.test.ts
+++ b/src/test/connection-streak.test.ts
@@ -19,6 +19,7 @@ suite("Connection Streak Test Suite", () => {
     context = getMockContext();
     dbPath = path.join(context.globalStorageUri.fsPath, "achievements.sqlite");
     db_lock._resetState();
+    db_model._resetState();
     await db_model.activate(context, dbPath);
     await db_init.activate(); // Initialize progressions
     originalDate = global.Date;

--- a/src/test/controllers.test.ts
+++ b/src/test/controllers.test.ts
@@ -19,6 +19,7 @@ suite("Controllers Test Suite", () => {
     context = getMockContext();
     dbPath = path.join(context.globalStorageUri.fsPath, "test.sqlite");
     db_lock._resetState();
+    db_model._resetState();
     await db_model.activate(context, dbPath);
   });
 

--- a/src/test/database.test.ts
+++ b/src/test/database.test.ts
@@ -15,6 +15,7 @@ suite("Database Model Test Suite", () => {
     dbPath = path.join(context.globalStorageUri.fsPath, "test.sqlite");
     // Reset lock state before each test
     db_lock._resetState();
+    db_model._resetState();
   });
 
   teardown(async () => {

--- a/src/test/listeners.test.ts
+++ b/src/test/listeners.test.ts
@@ -21,6 +21,7 @@ suite("Listeners Test Suite", () => {
     context = getMockContext();
     dbPath = path.join(context.globalStorageUri.fsPath, "test.sqlite");
     db_lock._resetState();
+    db_model._resetState();
     await db_model.activate(context, dbPath);
 
     // Create a dummy file

--- a/src/test/tables.test.ts
+++ b/src/test/tables.test.ts
@@ -18,6 +18,7 @@ suite("Tables Test Suite", () => {
     context = getMockContext();
     dbPath = path.join(context.globalStorageUri.fsPath, "test.sqlite");
     db_lock._resetState();
+    db_model._resetState();
     await db_model.activate(context, dbPath);
   });
 

--- a/src/views/components/AchievementsHolder.tsx
+++ b/src/views/components/AchievementsHolder.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Achievement from '../../database/model/tables/Achievement';
 import AchievementDisplay from './AchievementDisplay';
 import { PostMessage } from '../icons';
@@ -13,6 +13,7 @@ const AchievementHolder: React.FC<AchievementHolderProps> = ({ filters, limit })
   const [achievements, setAchievements] = useState<Achievement[]>([]);
   const [offset, setOffset] = useState(0);
   const [maxCount, setMaxCount] = useState(0);
+  const latestRequestId = useRef(0);
 
   useEffect(() => {
     window.addEventListener('message', handleMessage);
@@ -22,10 +23,11 @@ const AchievementHolder: React.FC<AchievementHolderProps> = ({ filters, limit })
   }, []);
 
   useEffect(() => {
+    const requestId = ++latestRequestId.current;
     window.vscode.postMessage(
       JSON.stringify({
         command: webview.commands.RETRIEVE_ACHIEVEMENTS,
-        data: { count: true, offset, limit, ...filters },
+        data: { count: true, offset, limit, ...filters, requestId },
       })
     );
   }, [offset, filters, limit]);
@@ -35,7 +37,14 @@ const AchievementHolder: React.FC<AchievementHolderProps> = ({ filters, limit })
       const data: PostMessage = event.data;
 
       if (data.command === webview.commands.DISPLAY_ACHIEVEMENTS) {
-        const payload = data.data as { achievements: Achievement[]; count: number };
+        const payload = data.data as {
+          achievements: Achievement[];
+          count: number;
+          requestId?: number;
+        };
+        if (payload.requestId !== latestRequestId.current) {
+          return;
+        }
         setAchievements(payload.achievements);
         setMaxCount(payload.count);
       }

--- a/src/views/components/SearchBar.tsx
+++ b/src/views/components/SearchBar.tsx
@@ -10,6 +10,7 @@ interface SearchBarProps {
 
 const SearchBar: React.FC<SearchBarProps> = ({ setFilters, limit, setLimit }) => {
   const [partialTitle, setPartialTitle] = useState('');
+  const [debouncedTitle, setDebouncedTitle] = useState('');
   const [achievable, setAchievable] = useState<true | undefined>(true);
   const [achieved, setAchieved] = useState<true | undefined>(undefined);
   const [label, setLabel] = useState<string | undefined>(undefined);
@@ -33,8 +34,15 @@ const SearchBar: React.FC<SearchBarProps> = ({ setFilters, limit, setLimit }) =>
   }, []);
 
   useEffect(() => {
+    const debounceHandle = setTimeout(() => {
+      setDebouncedTitle(partialTitle);
+    }, 250);
+    return () => clearTimeout(debounceHandle);
+  }, [partialTitle]);
+
+  useEffect(() => {
     setFilters({
-      title: partialTitle,
+      title: debouncedTitle,
       achievable,
       achieved,
       labels: label ? [label] : undefined,
@@ -42,7 +50,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ setFilters, limit, setLimit }) =>
       sortCriteria,
       sortDirection,
     });
-  }, [partialTitle, achievable, achieved, label, limit, sortCriteria, sortDirection, setFilters]);
+  }, [debouncedTitle, achievable, achieved, label, limit, sortCriteria, sortDirection, setFilters]);
 
   const handleMessage = (event: MessageEvent) => {
     try {

--- a/src/views/requests/backend.ts
+++ b/src/views/requests/backend.ts
@@ -44,7 +44,7 @@ export namespace backendRequests {
       const achievements = await AchievementController.getAchievements(filters);
       panel.webview.postMessage({
         command: webview.commands.DISPLAY_ACHIEVEMENTS,
-        data: achievements,
+        data: { ...achievements, requestId: filters.requestId },
       });
     } else {
       return;


### PR DESCRIPTION
This PR optimizes the search bar in the webview. It adds a debounce of 250ms to avoid stacking heavy join queries for each keystroke / filter edit instantly on the achievements search bar.

Fixes #65 