### PR TITLE
fix(security): add Content-Security-Policy and remove stray script tag

### DIFF
--- a/src/views/management.ts
+++ b/src/views/management.ts
@@ -47,6 +47,16 @@ export namespace AchievementsWebview {
     return panel;
   }
 
+  function getNonce(): string {
+    const possible =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let nonce = "";
+    for (let i = 0; i < 32; i++) {
+      nonce += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return nonce;
+  }
+
   function getDefaultWebviewContentReact(
     context: vscode.ExtensionContext,
     panel: vscode.WebviewPanel,
@@ -54,10 +64,12 @@ export namespace AchievementsWebview {
     const reactScriptUri = panel.webview.asWebviewUri(
       vscode.Uri.file(path.join(__dirname, "webview.js")),
     );
+    const nonce = getNonce();
     return `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${panel.webview.cspSource}; style-src ${panel.webview.cspSource}; script-src 'nonce-${nonce}';">
     <title>Achievements</title>
     <link rel="stylesheet" type="text/css" href="${panel.webview.asWebviewUri(
       vscode.Uri.file(
@@ -67,14 +79,13 @@ export namespace AchievementsWebview {
   </head>
   <body>
     <div id="achievement-view"></div>
-    <script src="${panel.webview.cspSource}"></script>
-    <script>
+    <script nonce="${nonce}">
       window.imageUris = ${JSON.stringify(
         getPackagedImages(context, panel.webview),
       )}
       window.vscode = acquireVsCodeApi();
     </script>
-    <script src="${reactScriptUri}"></script>
+    <script nonce="${nonce}" src="${reactScriptUri}"></script>
   </body>
 </html>` as const;
   }


### PR DESCRIPTION
This PR fixes a security issue in the webview:
- It enabled scripts but declared no CSP, so it could load or execute arbitrary content.
- It also contained a leftover <script src="${panel.webview.cspSource}"> tag using cspSource (a CSP directive value, not a URL) as a script source.

It adds a restrictive CSP meta tag scoped to the webview's own resources and require a nonce on every script tag, and remove the dead script tag.

Fixes #61 