### PR TITLE
chore: clean up dead code, misleading comments and small maintainability issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
           "achievements.listeners.git": {
             "type": "boolean",
             "default": true,
-            "description": "Enable or disable git evens listeners for the Achievements extension."
+            "description": "Enable or disable git events listeners for the Achievements extension."
           },
           "achievements.listeners.tabs": {
             "type": "boolean",

--- a/src/database/model/tables/DailySession.ts
+++ b/src/database/model/tables/DailySession.ts
@@ -45,11 +45,8 @@ export class DailySession {
       statement.free();
       await db_model.saveDB();
 
-      // Get the inserted ID. Note: In a concurrent environment this might be risky,
-      // but sql.js is single threaded and we are in a controlled environment.
-      // Better would be to use RETURNING clause if supported or a separate select.
-      // SQLite supports RETURNING since 3.35.0. sql.js is based on recent SQLite.
-      // Let's try to fetch it back by date which is unique.
+      // Fetch the inserted row back by its unique date, since sql.js's API
+      // does not expose the RETURNING clause.
       const newSession = db_model.get<DailySessionDict>(
         db,
         `SELECT * FROM daily_sessions WHERE date = ?`,

--- a/src/listeners/debug.ts
+++ b/src/listeners/debug.ts
@@ -1,7 +1,7 @@
 /**
  * Debug events listeners for achievements extension
  *
- * @namespace debuglListeners
+ * @namespace debugListeners
  * @author BoxBoxJason
  */
 

--- a/src/listeners/time.ts
+++ b/src/listeners/time.ts
@@ -92,7 +92,6 @@ export namespace timeListeners {
    * Get the current daily session, create a new one if none is found
    *
    * @returns {DailySession} - Current daily session
-   * @throws {Error} - Multiple daily sessions found for the same day
    */
   async function getCurrentDailySession(): Promise<DailySession> {
     const currentDay = new Date().toISOString().split("T")[0];
@@ -100,14 +99,7 @@ export namespace timeListeners {
       return dailySession;
     }
 
-    const dailySessions = await DailySession.getSessions(currentDay, currentDay);
-    if (dailySessions.length === 0) {
-      return await DailySession.getOrCreate(currentDay, 0);
-    } else if (dailySessions.length > 1) {
-      throw new Error("multiple daily sessions found for the same day");
-    } else {
-      return dailySessions[0];
-    }
+    return await DailySession.getOrCreate(currentDay, 0);
   }
 
   /**

--- a/src/test/constants.test.ts
+++ b/src/test/constants.test.ts
@@ -1,0 +1,29 @@
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { constants } from "../constants";
+
+suite("Constants Test Suite", () => {
+  // Assuming the tests are running from dist/test
+  const projectRoot = path.resolve(__dirname, "../../");
+
+  test("ignore.files/directories defaults match package.json configuration defaults", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, "package.json"), "utf-8"),
+    ) as {
+      contributes: {
+        configuration: { properties: Record<string, { default?: unknown }> }[];
+      };
+    };
+    const properties = packageJson.contributes.configuration[0].properties;
+
+    assert.deepStrictEqual(
+      properties["achievements.ignore.files"].default,
+      [...constants.ignore.DEFAULT_FILES],
+    );
+    assert.deepStrictEqual(
+      properties["achievements.ignore.directories"].default,
+      [...constants.ignore.DEFAULT_DIRECTORIES],
+    );
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -39,6 +39,7 @@ export namespace logger {
   let logFilePath = path.join(__dirname, LOG_FILENAME);
   const maxFileSizeBytes = 15 * 1024 * 1024; // 15 MB
   const outputChannel = vscode.window.createOutputChannel("Achievements Logs");
+  let ensuredLogDir: string | undefined;
 
   /**
    * Sets the log level for the logger
@@ -69,6 +70,7 @@ export namespace logger {
   export function setLogDir(directory: string) {
     logFilePath = path.join(directory, LOG_FILENAME);
     fs.mkdirSync(directory, { recursive: true });
+    ensuredLogDir = directory;
   }
 
   /**
@@ -219,9 +221,18 @@ export namespace logger {
   function logToFile(message: string) {
     try {
       const logDir = path.dirname(logFilePath);
-      fs.mkdirSync(logDir, { recursive: true });
+      if (logDir !== ensuredLogDir) {
+        fs.mkdirSync(logDir, { recursive: true });
+        ensuredLogDir = logDir;
+      }
       rotateLogFile();
-      fs.appendFileSync(logFilePath, message + "\n");
+      fs.appendFile(logFilePath, message + "\n", (error) => {
+        if (error) {
+          outputChannel.appendLine(
+            `${LOG_LEVELS_SLUG.ERROR}: Failed to write log to file: ${error.message}`,
+          );
+        }
+      });
     } catch (error) {
       outputChannel.appendLine(
         `${LOG_LEVELS_SLUG.ERROR}: Failed to write log to file: ${
@@ -242,10 +253,12 @@ export namespace logger {
   function rotateLogFile() {
     if (!fs.existsSync(logFilePath)) {
       return;
-    } else if (!fs.statSync(logFilePath).isFile()) {
+    }
+    const stats = fs.statSync(logFilePath);
+    if (!stats.isFile()) {
       logger.error(`Failed to rotate log file: ${logFilePath} is not a file`);
       return;
-    } else if (fs.statSync(logFilePath).size < maxFileSizeBytes) {
+    } else if (stats.size < maxFileSizeBytes) {
       return;
     } else {
       const rotatedLogFilePath = logFilePath.replace(

--- a/src/views/requests/backend.ts
+++ b/src/views/requests/backend.ts
@@ -9,6 +9,7 @@ import Achievement, {
 import { PostMessage } from "../icons";
 import { webview } from "../viewconst";
 import * as vscode from "vscode";
+import logger from "../../utils/logger";
 
 export namespace backendRequests {
   export async function handleMessage(
@@ -32,7 +33,7 @@ export namespace backendRequests {
         await handleProfileSelect(panel);
         break;
       default:
-        console.error("Unknown command: " + message.command);
+        logger.error("Unknown command: " + message.command);
     }
   }
 

--- a/src/views/requests/frontend.ts
+++ b/src/views/requests/frontend.ts
@@ -1,1 +1,0 @@
-export namespace frontendRequests {}


### PR DESCRIPTION
This PR performs multiple cleanup tasks in the codebase:

- Remove empty, unused frontendRequests namespace/file
- Add test asserting ignore.files/directories defaults stay in sync between constants.ts and package.json
- Replace unreachable "multiple daily sessions" branch with a direct DailySession.getOrCreate call (date column is UNIQUE)
- Capture fs.statSync result once in logger's rotateLogFile
- Avoid redundant mkdirSync and blocking appendFileSync on every log line in logger's hot path
- Use the shared logger instead of console.error for unknown webview commands
- Fix stale comment and namespace-name typos (debuglListeners, "git evens")

Closes #69 