### PR TITLE
fix(privacy): gate marketplace outdated-extensions check behind opt-in setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Achievements is a Visual Studio Code extension that allows you to track your pro
 - A lock prevents multiple VS Code instances from writing the database at the same time.
   - If another instance is using the DB, the extension runs in **read-only** mode: listeners are disabled and a status bar item indicates the state.
 
+### Network access
+
+By default, this extension makes **no network requests** and works fully offline.
+
+The only exception is the optional `achievements.checkOutdatedExtensions` setting (disabled
+by default). When enabled, it periodically sends the IDs of your installed (non-builtin)
+extensions to the VS Marketplace (`marketplace.visualstudio.com`) to check for outdated
+versions and award related achievements. Enable it only if you're comfortable sharing your
+installed-extension list with the Marketplace.
+
 ## Extension Commands
 
 Several commands are available to interact with the Achievements extension. You can access these commands through the Command Palette (Ctrl+Shift+P) or by using keybindings.
@@ -58,6 +68,7 @@ You can also access the settings by using the command `achievements.settings`.
 |`achievements.listeners.debug`|Enable or disable debug listeners|
 |`achievements.listeners.git`|Enable or disable git listeners|
 |`achievements.listeners.extensions`|Enable or disable extension listeners|
+|`achievements.checkOutdatedExtensions`|Opt-in: check installed extensions against the VS Marketplace for outdated versions (sends your installed extension IDs over the network; disabled by default)|
 |`achievements.listeners.files`|Enable or disable file listeners|
 |`achievements.listeners.tabs`|Enable or disable tab listeners|
 |`achievements.listeners.tasks`|Enable or disable task listeners|

--- a/package.json
+++ b/package.json
@@ -84,7 +84,12 @@
           "achievements.listeners.extensions": {
             "type": "boolean",
             "default": true,
-            "description": "Enable or disable extensions / themes events listeners for the Achievements extension."
+            "description": "Enable or disable extensions / themes events listeners for the Achievements extension. This only tracks locally installed/enabled extensions and does not make any network request; see achievements.checkOutdatedExtensions for the opt-in Marketplace check."
+          },
+          "achievements.checkOutdatedExtensions": {
+            "type": "boolean",
+            "default": false,
+            "description": "Opt-in: periodically send the IDs of your installed (non-builtin) extensions to the VS Marketplace (marketplace.visualstudio.com) to check for outdated versions and award related achievements. Disabled by default since this is the only network request made by this extension."
           },
           "achievements.listeners.files": {
             "type": "boolean",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -20,6 +20,7 @@ export interface Config {
   notifications: boolean;
   logDirectory: string;
   username: string;
+  checkOutdatedExtensions: boolean;
   ignore: {
     files: string[];
     directories: string[];
@@ -126,6 +127,10 @@ export namespace config {
       username: extensionRawConfig
         .get<string>("username", webview.DEFAULT_USER)
         .trim(),
+      checkOutdatedExtensions: extensionRawConfig.get<boolean>(
+        "checkOutdatedExtensions",
+        false,
+      ),
       ignore: {
         files: extensionRawConfig
           .get<string[]>("ignore.files", [...constants.ignore.DEFAULT_FILES])
@@ -206,6 +211,22 @@ export namespace config {
    */
   export function notificationsEnabled(): boolean {
     return getConfig().notifications;
+  }
+
+  /**
+   * Returns whether checking for outdated extensions against the VS
+   * Marketplace is enabled. This is opt-in and separate from
+   * `listeners.extensions`, since it makes a network request that sends the
+   * user's installed extension IDs to a third-party server.
+   *
+   * @memberof config
+   * @function checkOutdatedExtensionsEnabled
+   *
+   * @returns {boolean} - Whether the outdated extensions check is enabled
+   * @throws {Error} - If the module has not been initialized
+   */
+  export function checkOutdatedExtensionsEnabled(): boolean {
+    return getConfig().checkOutdatedExtensions;
   }
 
   /**

--- a/src/listeners/extensions.ts
+++ b/src/listeners/extensions.ts
@@ -189,12 +189,16 @@ export namespace extensionsListeners {
         context.subscriptions,
       );
 
-      vscode.extensions.onDidChange(
-        () =>
-          checkOutdatedExtensions().catch((err: unknown) => logger.error(err)),
-        null,
-        context.subscriptions,
-      );
+      if (config.checkOutdatedExtensionsEnabled()) {
+        vscode.extensions.onDidChange(
+          () =>
+            checkOutdatedExtensions().catch((err: unknown) =>
+              logger.error(err),
+            ),
+          null,
+          context.subscriptions,
+        );
+      }
 
       vscode.window.onDidChangeActiveColorTheme(
         handleThemeChange,
@@ -206,7 +210,12 @@ export namespace extensionsListeners {
 
       // Check the total number of installed extensions at the boot
       checkExtensions().catch((err: unknown) => logger.error(err));
-      checkOutdatedExtensions().catch((err: unknown) => logger.error(err));
+
+      // Opt-in only: this sends the user's installed extension IDs to the
+      // VS Marketplace over the network. See achievements.checkOutdatedExtensions.
+      if (config.checkOutdatedExtensionsEnabled()) {
+        checkOutdatedExtensions().catch((err: unknown) => logger.error(err));
+      }
     } else {
       logger.info("Extensions events listeners are disabled");
     }


### PR DESCRIPTION
This PR makes the outdated extension achievement opt in (disabled by default).

This is used to ensure not involuntarely leaking installed (non builtin) extension to the vscode marketplace. A parameter now exists and can be configured from the settings to enable / disable it.

Fixes #63 