### PR TITLE
feat: create copy ninja pastes listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can also access the settings by using the command `achievements.settings`.
 |`achievements.listeners.extensions`|Enable or disable extension listeners|
 |`achievements.checkOutdatedExtensions`|Opt-in: check installed extensions against the VS Marketplace for outdated versions (sends your installed extension IDs over the network; disabled by default)|
 |`achievements.listeners.files`|Enable or disable file listeners|
+|`achievements.listeners.shortcuts`|Enable or disable paste shortcut listeners|
 |`achievements.listeners.tabs`|Enable or disable tab listeners|
 |`achievements.listeners.tasks`|Enable or disable task listeners|
 |`achievements.listeners.time`|Enable or disable time tracking listeners|

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
             "default": true,
             "description": "Enable or disable git events listeners for the Achievements extension."
           },
+          "achievements.listeners.shortcuts": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable paste shortcut events listeners for the Achievements extension."
+          },
           "achievements.listeners.tabs": {
             "type": "boolean",
             "default": true,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -30,6 +30,7 @@ export interface Config {
     extensions: boolean;
     files: boolean;
     git: boolean;
+    shortcuts: boolean;
     tabs: boolean;
     tasks: boolean;
     time: boolean;
@@ -153,6 +154,10 @@ export namespace config {
         ),
         files: extensionRawConfig.get<boolean>("listeners.files", true),
         git: extensionRawConfig.get<boolean>("listeners.git", true),
+        shortcuts: extensionRawConfig.get<boolean>(
+          "listeners.shortcuts",
+          true,
+        ),
         tabs: extensionRawConfig.get<boolean>("listeners.tabs", true),
         tasks: extensionRawConfig.get<boolean>("listeners.tasks", true),
         time: extensionRawConfig.get<boolean>("listeners.time", true),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -219,6 +219,7 @@ export namespace constants {
     EXTENSIONS: "extensions",
     FILES: "files",
     GIT: "git",
+    SHORTCUTS: "shortcuts",
     TABS: "tabs",
     TASKS: "tasks",
     TIME: "time",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { tabListeners } from "./listeners/tabs";
 import { taskListeners } from "./listeners/tasks";
 import { extensionsListeners } from "./listeners/extensions";
 import { debugListeners } from "./listeners/debug";
+import { shortcutsListeners } from "./listeners/shortcuts";
 import logger from "./utils/logger";
 
 /**
@@ -136,6 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
     taskListeners.activate(context);
     extensionsListeners.activate(context);
     debugListeners.activate(context);
+    shortcutsListeners.activate(context);
   } else if (!hasWriteAccess) {
     // If we don't have write access, show a UI warning and keep listeners disabled
     showReadOnlyUI(context);

--- a/src/listeners/files.ts
+++ b/src/listeners/files.ts
@@ -43,7 +43,7 @@ function refreshIgnoredMatchers(): void {
  * @param {vscode.Uri} uri - The URI to check
  * @returns {boolean} True if the URI should be ignored, false otherwise
  */
-function shouldIgnoreUri(uri: vscode.Uri): boolean {
+export function shouldIgnoreUri(uri: vscode.Uri): boolean {
   if (uri.scheme !== "file") {
     return true;
   }

--- a/src/listeners/shortcuts.ts
+++ b/src/listeners/shortcuts.ts
@@ -1,0 +1,76 @@
+/**
+ * Shortcut events listeners for achievements extension.
+ * Tracks paste operations (Copy Ninja).
+ *
+ * @namespace shortcutsListeners
+ * @author BoxBoxJason
+ */
+
+import * as vscode from "vscode";
+import { ProgressionController } from "../database/controller/progressions";
+import { constants } from "../constants";
+import logger from "../utils/logger";
+import { config } from "../config/config";
+import { shouldIgnoreUri } from "./files";
+
+/**
+ * Shortcut related events listeners functions and handlers
+ *
+ * @namespace shortcutsListeners
+ * @function activate - Create shortcut related events listeners
+ */
+export namespace shortcutsListeners {
+  /**
+   * Document paste edit provider used only for its side effect of tracking
+   * paste operations. It never replaces the default paste behavior.
+   *
+   * @memberof shortcutsListeners
+   */
+  export class AchievementsPasteEditProvider
+    implements vscode.DocumentPasteEditProvider
+  {
+    provideDocumentPasteEdits(
+      document: vscode.TextDocument,
+      _ranges: readonly vscode.Range[],
+      _dataTransfer: vscode.DataTransfer,
+      _context: vscode.DocumentPasteEditContext,
+      _token: vscode.CancellationToken,
+    ): vscode.ProviderResult<vscode.DocumentPasteEdit[]> {
+      if (!shouldIgnoreUri(document.uri)) {
+        ProgressionController.increaseProgression(
+          constants.criteria.NUMBER_OF_PASTES,
+        ).catch((err: unknown) => logger.error(err));
+      }
+      // Returning undefined lets VS Code perform the default, unmodified
+      // paste - this handler never alters editor content.
+      return undefined;
+    }
+  }
+
+  /**
+   * Create shortcut related events listeners
+   *
+   * @param {vscode.ExtensionContext} context - Extension context
+   * @returns {void}
+   */
+  export function activate(context: vscode.ExtensionContext): void {
+    if (config.isListenerEnabled(constants.listeners.SHORTCUTS)) {
+      logger.info("Starting shortcuts events listeners");
+
+      context.subscriptions.push(
+        vscode.languages.registerDocumentPasteEditProvider(
+          { scheme: "file" },
+          new AchievementsPasteEditProvider(),
+          {
+            providedPasteEditKinds: [vscode.DocumentDropOrPasteEditKind.Text],
+            pasteMimeTypes: ["text/plain"],
+          },
+        ),
+      );
+
+      logger.debug("Shortcuts listeners activated");
+    } else {
+      logger.info("Shortcuts listeners are disabled");
+    }
+  }
+}

--- a/src/test/listeners/shortcuts.test.ts
+++ b/src/test/listeners/shortcuts.test.ts
@@ -1,0 +1,69 @@
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { shortcutsListeners } from "../../listeners/shortcuts";
+import { ProgressionController } from "../../database/controller/progressions";
+import { constants } from "../../constants";
+
+suite("Shortcuts Listeners Test Suite", () => {
+  const tempDir = path.join(__dirname, "temp_shortcuts_test");
+
+  test("provideDocumentPasteEdits should increase NUMBER_OF_PASTES and let the default paste proceed", () => {
+    const uri = vscode.Uri.file(path.join(tempDir, "test.ts"));
+    const document = { uri } as vscode.TextDocument;
+
+    const increasedCriteria: string[] = [];
+    const originalIncrease = ProgressionController.increaseProgression;
+    ProgressionController.increaseProgression = async (criteria: string) => {
+      increasedCriteria.push(criteria);
+    };
+
+    try {
+      const provider = new shortcutsListeners.AchievementsPasteEditProvider();
+      const result = provider.provideDocumentPasteEdits(
+        document,
+        [],
+        {} as vscode.DataTransfer,
+        {} as vscode.DocumentPasteEditContext,
+        {} as vscode.CancellationToken,
+      );
+
+      assert.strictEqual(
+        result,
+        undefined,
+        "Provider should never replace the default paste behavior",
+      );
+      assert.ok(increasedCriteria.includes(constants.criteria.NUMBER_OF_PASTES));
+    } finally {
+      ProgressionController.increaseProgression = originalIncrease;
+    }
+  });
+
+  test("provideDocumentPasteEdits should ignore configured files", () => {
+    const uri = vscode.Uri.file(
+      path.join(tempDir, "node_modules", "bundle.ts"),
+    );
+    const document = { uri } as vscode.TextDocument;
+
+    let callCount = 0;
+    const originalIncrease = ProgressionController.increaseProgression;
+    ProgressionController.increaseProgression = async () => {
+      callCount++;
+    };
+
+    try {
+      const provider = new shortcutsListeners.AchievementsPasteEditProvider();
+      provider.provideDocumentPasteEdits(
+        document,
+        [],
+        {} as vscode.DataTransfer,
+        {} as vscode.DocumentPasteEditContext,
+        {} as vscode.CancellationToken,
+      );
+      assert.strictEqual(callCount, 0);
+    } finally {
+      ProgressionController.increaseProgression = originalIncrease;
+    }
+  });
+
+});


### PR DESCRIPTION
This PR adds a new listener to activate the copy ninja (paste) achievement.

- Register a DocumentPasteEditProvider that increments NUMBER_OF_PASTES as a side effect and always lets the default, unmodified paste proceed (covers Ctrl+V, right-click paste and the Edit menu, unlike a keybinding override).
- New achievements.listeners.shortcuts setting (default enabled) to toggle the achievement, consistent with the other listener families.

Closes #70 