### PR TITLE
fix: only one early bird / nigh owl trigger per day

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,8 +64,10 @@ export namespace constants {
     TERMINALS_OPENED = "terminalsOpenedCount",
     // Coding sessions started late at night (local time)
     NIGHT_OWL_SESSIONS = "nightOwlSessionsCount",
+    LAST_NIGHT_OWL_DATE = "lastNightOwlDate",
     // Coding sessions started early in the morning (local time)
     EARLY_BIRD_SESSIONS = "earlyBirdSessionsCount",
+    LAST_EARLY_BIRD_DATE = "lastEarlyBirdDate",
     // Opened workspace folders (multi-root workspaces)
     NUMBER_OF_SIMULTANEOUS_WORKSPACE_FOLDERS = "simultaneousWorkspaceFoldersCount",
     // Time spent connected to a remote / container development window

--- a/src/database/model/init/init.ts
+++ b/src/database/model/init/init.ts
@@ -103,7 +103,9 @@ export namespace db_init {
       if (
         criteria !== constants.criteria.LINES_OF_CODE_LANGUAGE &&
         criteria !== constants.criteria.FILES_CREATED_LANGUAGE &&
-        criteria !== constants.criteria.LAST_STREAK_DATE
+        criteria !== constants.criteria.LAST_STREAK_DATE &&
+        criteria !== constants.criteria.LAST_NIGHT_OWL_DATE &&
+        criteria !== constants.criteria.LAST_EARLY_BIRD_DATE
       ) {
         const progression = new Progression({
           name: criteria,
@@ -111,7 +113,11 @@ export namespace db_init {
           value: 0,
         });
         progressions.push(progression);
-      } else if (criteria === constants.criteria.LAST_STREAK_DATE) {
+      } else if (
+        criteria === constants.criteria.LAST_STREAK_DATE ||
+        criteria === constants.criteria.LAST_NIGHT_OWL_DATE ||
+        criteria === constants.criteria.LAST_EARLY_BIRD_DATE
+      ) {
         const progression = new Progression({
           name: criteria,
           type: "string",

--- a/src/listeners/time.ts
+++ b/src/listeners/time.ts
@@ -10,6 +10,7 @@ import { DailySession } from "../database/model/tables/DailySession";
 import { TimeSpentController } from "../database/controller/timespent";
 import { db_model } from "../database/model/model";
 import { ProgressionController } from "../database/controller/progressions";
+import Progression from "../database/model/tables/Progression";
 import logger from "../utils/logger";
 import { config } from "../config/config";
 import { constants } from "../constants";
@@ -139,14 +140,52 @@ export namespace timeListeners {
   ): Promise<void> {
     const hour = sessionStartDate.getHours();
     if (hour >= NIGHT_OWL_START_HOUR && hour < NIGHT_OWL_END_HOUR) {
-      await ProgressionController.increaseProgression(
-        constants.criteria.NIGHT_OWL_SESSIONS
+      await trackTimeOfDaySessionOnce(
+        constants.criteria.LAST_NIGHT_OWL_DATE,
+        constants.criteria.NIGHT_OWL_SESSIONS,
+        sessionStartDate
       );
     } else if (hour >= EARLY_BIRD_START_HOUR && hour < EARLY_BIRD_END_HOUR) {
-      await ProgressionController.increaseProgression(
-        constants.criteria.EARLY_BIRD_SESSIONS
+      await trackTimeOfDaySessionOnce(
+        constants.criteria.LAST_EARLY_BIRD_DATE,
+        constants.criteria.EARLY_BIRD_SESSIONS,
+        sessionStartDate
       );
     }
+  }
+
+  /**
+   * Increase a time-of-day flavor achievement's progression at most once per
+   * calendar day, guarded by a persisted "last tracked date" progression.
+   * Prevents the achievement from being awarded multiple times when a window
+   * is focused/blurred repeatedly within the same night-owl/early-bird window.
+   *
+   * @param {string} lastDateCriteria - Criteria name storing the last tracked date
+   * @param {string} sessionsCriteria - Criteria name to increase
+   * @param {Date} sessionStartDate - The date/time the session started at
+   * @returns {Promise<void>}
+   */
+  async function trackTimeOfDaySessionOnce(
+    lastDateCriteria: string,
+    sessionsCriteria: string,
+    sessionStartDate: Date
+  ): Promise<void> {
+    const currentDateString = sessionStartDate.toISOString().split("T")[0];
+
+    const lastDateProgressions = await Progression.getProgressions({
+      name: lastDateCriteria,
+    });
+    const lastDateProgression = lastDateProgressions[0];
+
+    if (lastDateProgression?.value === currentDateString) {
+      return;
+    }
+
+    await ProgressionController.increaseProgression(sessionsCriteria);
+    await ProgressionController.updateProgression(
+      lastDateCriteria,
+      currentDateString
+    );
   }
 
   /**

--- a/src/test/listeners/time.test.ts
+++ b/src/test/listeners/time.test.ts
@@ -1,10 +1,32 @@
 import * as assert from "node:assert";
 import * as vscode from "vscode";
+import * as path from "node:path";
 import { timeListeners } from "../../listeners/time";
 import { ProgressionController } from "../../database/controller/progressions";
 import { constants } from "../../constants";
+import { db_model } from "../../database/model/model";
+import { db_lock } from "../../database/lock";
+import { db_init } from "../../database/model/init/init";
+import { getMockContext, cleanupMockContext } from "../utils";
 
 suite("Time Listeners Test Suite", () => {
+  let context: vscode.ExtensionContext;
+  let dbPath: string;
+
+  setup(async () => {
+    context = getMockContext();
+    dbPath = path.join(context.globalStorageUri.fsPath, "achievements.sqlite");
+    db_lock._resetState();
+    db_model._resetState();
+    await db_model.activate(context, dbPath);
+    await db_init.activate(); // Initialize progressions
+  });
+
+  teardown(async () => {
+    await db_model.deactivate();
+    cleanupMockContext(context);
+  });
+
   test("trackTimeOfDaySession should increase NIGHT_OWL_SESSIONS for late-night hours", async () => {
     const increasedCriteria: string[] = [];
     const originalIncrease = ProgressionController.increaseProgression;

--- a/src/test/time-of-day-dedup.test.ts
+++ b/src/test/time-of-day-dedup.test.ts
@@ -1,0 +1,62 @@
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { db_model } from "../database/model/model";
+import { db_lock } from "../database/lock";
+import { db_init } from "../database/model/init/init";
+import { ProgressionController } from "../database/controller/progressions";
+import { timeListeners } from "../listeners/time";
+import { constants } from "../constants";
+import { getMockContext, cleanupMockContext } from "./utils";
+
+suite("Time Of Day Session Dedup Test Suite", () => {
+  let context: vscode.ExtensionContext;
+  let dbPath: string;
+
+  setup(async () => {
+    context = getMockContext();
+    dbPath = path.join(context.globalStorageUri.fsPath, "achievements.sqlite");
+    db_lock._resetState();
+    db_model._resetState();
+    await db_model.activate(context, dbPath);
+    await db_init.activate(); // Initialize progressions
+  });
+
+  teardown(async () => {
+    await db_model.deactivate();
+    cleanupMockContext(context);
+  });
+
+  test("NIGHT_OWL_SESSIONS is only increased once per day", async () => {
+    const first = new Date(2026, 0, 1, 1, 0, 0);
+    const second = new Date(2026, 0, 1, 3, 0, 0);
+
+    await timeListeners.trackTimeOfDaySession(first);
+    await timeListeners.trackTimeOfDaySession(second);
+
+    const progs = await ProgressionController.getProgressions();
+    assert.strictEqual(progs[constants.criteria.NIGHT_OWL_SESSIONS], 1);
+  });
+
+  test("NIGHT_OWL_SESSIONS is increased again on a subsequent day", async () => {
+    const day1 = new Date(2026, 0, 1, 1, 0, 0);
+    const day2 = new Date(2026, 0, 2, 1, 0, 0);
+
+    await timeListeners.trackTimeOfDaySession(day1);
+    await timeListeners.trackTimeOfDaySession(day2);
+
+    const progs = await ProgressionController.getProgressions();
+    assert.strictEqual(progs[constants.criteria.NIGHT_OWL_SESSIONS], 2);
+  });
+
+  test("EARLY_BIRD_SESSIONS is only increased once per day", async () => {
+    const first = new Date(2026, 0, 1, 5, 30, 0);
+    const second = new Date(2026, 0, 1, 6, 45, 0);
+
+    await timeListeners.trackTimeOfDaySession(first);
+    await timeListeners.trackTimeOfDaySession(second);
+
+    const progs = await ProgressionController.getProgressions();
+    assert.strictEqual(progs[constants.criteria.EARLY_BIRD_SESSIONS], 1);
+  });
+});


### PR DESCRIPTION
This PR fixes a bug that allowed users to trigger multiple early bird / night owl progressions in the same day.