### PR TITLE
docs: add extension walkthrough

### DIFF
--- a/docs/walkthroughs/getting-started/configure.md
+++ b/docs/walkthroughs/getting-started/configure.md
@@ -1,0 +1,8 @@
+# Choose what gets tracked
+
+Open settings and search for "Achievements" (or run **Achievements: Settings**) to:
+
+- Toggle `achievements.notifications` if you don't want a popup on unlock.
+- Turn off any `achievements.listeners.*` setting to stop tracking that category entirely (files, git, tabs, tasks, extensions, debug, time, shortcuts). Each one is independent !
+
+By default this extension makes **no network requests** and works fully offline. The only exception is the opt-in `achievements.checkOutdatedExtensions` setting, disabled unless you turn it on yourself.

--- a/docs/walkthroughs/getting-started/first-achievement.md
+++ b/docs/walkthroughs/getting-started/first-achievement.md
@@ -1,0 +1,5 @@
+# Just keep coding
+
+Achievements unlock from things you're already doing: saving files, committing, switching tabs, running tasks, and more. There's nothing to trigger manually.
+
+When one unlocks, you'll get a notification (unless you disabled those), and it'll show as completed the next time you open the **Achievements** panel.

--- a/docs/walkthroughs/getting-started/open-panel.md
+++ b/docs/walkthroughs/getting-started/open-panel.md
@@ -1,0 +1,9 @@
+# Your Achievements panel
+
+The **Achievements** panel is a webview that shows:
+
+- Your profile and overall completion percentage
+- Every achievement, with its description, category, and progress
+- Filters by category, progress, and name
+
+Run **Achievements: Show** from the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) any time to reopen it, nothing here requires a restart.

--- a/docs/walkthroughs/getting-started/username.md
+++ b/docs/walkthroughs/getting-started/username.md
@@ -1,0 +1,5 @@
+# Set your username
+
+Open settings and search for "Achievements" (or run **Achievements: Settings**), then set `achievements.username`.
+
+It's shown on your profile in the Achievements panel. This is purely cosmetic, stored locally, never sent anywhere.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,69 @@
         "title": "Achievements: Show"
       }
     ],
+    "walkthroughs": [
+      {
+        "id": "achievements.gettingStarted",
+        "title": "Get Started with Achievements",
+        "description": "Track your coding journey and earn achievements as you work.",
+        "icon": "icon.png",
+        "steps": [
+          {
+            "id": "showcase",
+            "title": "Install Achievements and see what it can do",
+            "description": "A quick look at the Achievements panel.",
+            "media": {
+              "image": "docs/achievements.gif",
+              "altText": "Extension Webview Illustration"
+            },
+            "completionEvents": [
+              "extensionInstalled:boxboxjason.achievements"
+            ]
+          },
+          {
+            "id": "openPanel",
+            "title": "Open your Achievements panel",
+            "description": "See your progress, profile, and every achievement's requirements in one place.\n[Open Achievements](command:achievements.show)",
+            "media": {
+              "markdown": "docs/walkthroughs/getting-started/open-panel.md"
+            },
+            "completionEvents": [
+              "onCommand:achievements.show"
+            ]
+          },
+          {
+            "id": "setUsername",
+            "title": "Set your username",
+            "description": "Your username is shown on your profile in the Achievements panel.\n[Open Settings](command:achievements.settings)",
+            "media": {
+              "markdown": "docs/walkthroughs/getting-started/username.md"
+            },
+            "completionEvents": [
+              "onSettingChanged:achievements.username"
+            ]
+          },
+          {
+            "id": "configure",
+            "title": "Choose what gets tracked",
+            "description": "Every listener can be turned off individually: nothing here is all-or-nothing.\n[Open Settings](command:achievements.settings)",
+            "media": {
+              "markdown": "docs/walkthroughs/getting-started/configure.md"
+            },
+            "completionEvents": [
+              "onCommand:achievements.settings"
+            ]
+          },
+          {
+            "id": "firstAchievement",
+            "title": "Earn your first achievement",
+            "description": "Keep coding as usual: achievements unlock automatically and a notification will let you know.",
+            "media": {
+              "markdown": "docs/walkthroughs/getting-started/first-achievement.md"
+            }
+          }
+        ]
+      }
+    ],
     "configuration": [
       {
         "title": "achievements",
@@ -213,6 +276,7 @@
   "files": [
     "dist",
     "assets",
+    "docs",
     "README.md",
     "CHANGELOG.md",
     "LICENSE.md",


### PR DESCRIPTION
This PR adds the walkthrough for the extension.

This is a guide that is displayed and can be followed by users to understand how the extension works, what they can do with it,...

Closes #100 