### PR TITLE
feat: add status bar item & quickpick summary menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "achievements",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "achievements",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "proper-lockfile": "4.1.2",
         "react": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       {
         "command": "achievements.show",
         "title": "Achievements: Show"
+      },
+      {
+        "command": "achievements.statusBarMenu",
+        "title": "Achievements: Quick Menu"
       }
     ],
     "walkthroughs": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": {
     "name": "BoxBoxJason"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "vscode": "^1.125.0"
   },

--- a/src/database/controller/achievements.ts
+++ b/src/database/controller/achievements.ts
@@ -10,6 +10,7 @@ import Achievement, {
   AchievementRow,
   AchievementSelectRequestFilters,
 } from "../model/tables/Achievement";
+import { ProgressionController, ProgressionDict } from "./progressions";
 
 // ==================== MODULE FUNCTIONS ====================
 /**
@@ -20,6 +21,9 @@ import Achievement, {
  * @function getAchievements - Retrieve achievements in a raw format given a set of filters
  * @function getJsonAchievements - Retrieve achievements in a raw format given a set of filters
  * @function getJsonFilters - Retrieve the categories, groups, and labels of all achievements
+ * @function getClosestAchievableAchievement - Retrieve the unlocked achievement closest to completion, if any
+ * @function getLatestAchievedAchievement - Retrieve the most recently unlocked, non-hidden achievement, if any
+ * @function computeCompletionRatio - Compute how close an achievement's criteria are to being met
  * @function parseFilters - Parse the filters and set default values if necessary
  */
 export namespace AchievementController {
@@ -108,6 +112,109 @@ export namespace AchievementController {
       groups: await Achievement.getGroups(),
       labels: await Achievement.getLabels(),
     };
+  }
+
+  /**
+   * Compute how close an achievement's criteria are to being met, as a
+   * ratio between 0 (untouched) and 1 (met). An achievement requires every
+   * criterion to be met, so the ratio is the bottleneck (minimum) across
+   * all of its criteria rather than an average.
+   *
+   * @memberof achievements
+   * @function computeCompletionRatio
+   *
+   * @param {Object} criteria - The achievement's criteria, keyed by progression name
+   * @param {ProgressionDict} progressions - The current progression values, keyed by name
+   * @returns {number} - The completion ratio, between 0 and 1
+   */
+  export function computeCompletionRatio(
+    criteria: { [key: string]: unknown },
+    progressions: ProgressionDict,
+  ): number {
+    const requirements = Object.entries(criteria);
+    if (requirements.length === 0) {
+      return 0;
+    }
+
+    let ratio = 1;
+    for (const [progressionName, requiredValue] of requirements) {
+      const currentValue = progressions[progressionName];
+      let criterionRatio: number;
+      if (typeof requiredValue === "number") {
+        const current = typeof currentValue === "number" ? currentValue : 0;
+        criterionRatio =
+          requiredValue <= 0 ? 1 : Math.min(1, Math.max(0, current / requiredValue));
+      } else {
+        // Non-numeric criteria (booleans, dates, strings) are treated as
+        // binary: either the current value satisfies it or it doesn't.
+        criterionRatio = currentValue === requiredValue ? 1 : 0;
+      }
+      ratio = Math.min(ratio, criterionRatio);
+    }
+    return ratio;
+  }
+
+  /**
+   * Retrieve the not-yet-achieved, non-hidden achievement whose criteria
+   * are closest to being met among those the user can currently work
+   * towards (prerequisites already unlocked). Ties are broken randomly.
+   *
+   * @memberof achievements
+   * @function getClosestAchievableAchievement
+   *
+   * @returns {Promise<{ achievement: Achievement; ratio: number } | undefined>} - The closest achievement and its completion ratio, if any
+   */
+  export async function getClosestAchievableAchievement(): Promise<
+    { achievement: Achievement; ratio: number } | undefined
+  > {
+    const { achievements } = await getAchievements({
+      achieved: false,
+      hidden: false,
+      achievable: true,
+      limit: 1000,
+    });
+    if (achievements.length === 0) {
+      return undefined;
+    }
+
+    const progressions = await ProgressionController.getProgressions();
+
+    let bestRatio = -1;
+    let bestAchievements: Achievement[] = [];
+    for (const achievement of achievements) {
+      const ratio = computeCompletionRatio(achievement.criteria, progressions);
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        bestAchievements = [achievement];
+      } else if (ratio === bestRatio) {
+        bestAchievements.push(achievement);
+      }
+    }
+
+    const picked =
+      bestAchievements[Math.floor(Math.random() * bestAchievements.length)];
+    return { achievement: picked, ratio: bestRatio };
+  }
+
+  /**
+   * Retrieve the most recently unlocked, non-hidden achievement.
+   *
+   * @memberof achievements
+   * @function getLatestAchievedAchievement
+   *
+   * @returns {Promise<Achievement | undefined>} - The most recently unlocked achievement, if any
+   */
+  export async function getLatestAchievedAchievement(): Promise<
+    Achievement | undefined
+  > {
+    const { achievements } = await getAchievements({
+      achieved: true,
+      hidden: false,
+      sortCriteria: "achievedAt",
+      sortDirection: "DESC",
+      limit: 1,
+    });
+    return achievements[0];
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { db_model } from "./database/model/model";
 import { config } from "./config/config";
 import { AchievementsWebview } from "./views/management";
+import { registerAchievementsStatusBar } from "./views/statusbar";
 import { fileListeners } from "./listeners/files";
 import { gitListeners } from "./listeners/git";
 import { timeListeners } from "./listeners/time";
@@ -125,6 +126,9 @@ export async function activate(context: vscode.ExtensionContext) {
     },
   );
   context.subscriptions.push(showAchievementsCommand);
+
+  // Status bar quick menu
+  registerAchievementsStatusBar(context);
 
   // ==================== LISTENERS ====================
   // Only activate listeners if we have write access (not in readonly mode)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,11 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(showAchievementsCommand);
 
   // Status bar quick menu
-  registerAchievementsStatusBar(context);
+  // Skipped in test mode: the test suite registers it directly against a
+  // mock context, which would collide with this real registration.
+  if (context.extensionMode !== vscode.ExtensionMode.Test) {
+    registerAchievementsStatusBar(context);
+  }
 
   // ==================== LISTENERS ====================
   // Only activate listeners if we have write access (not in readonly mode)

--- a/src/test/controllers.test.ts
+++ b/src/test/controllers.test.ts
@@ -121,6 +121,82 @@ suite("Controllers Test Suite", () => {
     assert.ok(result7.achievements.length > 0);
   });
 
+  test("AchievementController.computeCompletionRatio should compute the bottleneck ratio across criteria", () => {
+    const progressions = { a: 5, b: 2, c: "done" };
+
+    // No criteria at all
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio({}, progressions),
+      0,
+    );
+
+    // Single numeric criterion, partially met
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio({ a: 10 }, progressions),
+      0.5,
+    );
+
+    // Multiple numeric criteria: the least-complete one wins
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio(
+        { a: 10, b: 10 },
+        progressions,
+      ),
+      0.2,
+    );
+
+    // A non-positive requirement is trivially satisfied
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio({ a: 0 }, progressions),
+      1,
+    );
+
+    // Non-numeric criteria are all-or-nothing
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio({ c: "done" }, progressions),
+      1,
+    );
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio({ c: "nope" }, progressions),
+      0,
+    );
+
+    // A progression with no recorded value yet counts as 0
+    assert.strictEqual(
+      AchievementController.computeCompletionRatio(
+        { missing: 10 },
+        progressions,
+      ),
+      0,
+    );
+  });
+
+  test("AchievementController.getClosestAchievableAchievement should return the achievement closest to completion", async () => {
+    // On a fresh database every achievable achievement sits at ratio 0
+    await ProgressionController.updateProgression(
+      constants.criteria.FILES_CREATED,
+      1,
+    );
+
+    const result = await AchievementController.getClosestAchievableAchievement();
+    assert.ok(result);
+    assert.strictEqual(result?.achievement.title, "Creator 1");
+    assert.strictEqual(result?.ratio, 0.5);
+  });
+
+  test("AchievementController.getLatestAchievedAchievement should return the most recently unlocked achievement", async () => {
+    const beforeAny = await AchievementController.getLatestAchievedAchievement();
+    assert.strictEqual(beforeAny, undefined);
+
+    await ProgressionController.updateProgression(
+      constants.criteria.LINES_OF_CODE,
+      1,
+    );
+
+    const latest = await AchievementController.getLatestAchievedAchievement();
+    assert.strictEqual(latest?.title, "Code Monkey 1");
+  });
+
   test("TimeSpentController.updateTimeSpentFromSessions should update progressions", async () => {
     // Insert a daily session
     const today = new Date().toISOString().split("T")[0];

--- a/src/test/statusbar.test.ts
+++ b/src/test/statusbar.test.ts
@@ -1,0 +1,139 @@
+import * as assert from "node:assert";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import {
+  STATUS_BAR_MENU_COMMAND,
+  buildMenuItems,
+  formatProgressBar,
+  gatherStatusBarData,
+  registerAchievementsStatusBar,
+  StatusBarData,
+} from "../views/statusbar";
+import { getMockContext, cleanupMockContext } from "./utils";
+import { db_model } from "../database/model/model";
+import { db_lock } from "../database/lock";
+
+suite("Status Bar Test Suite", () => {
+  let context: vscode.ExtensionContext;
+
+  setup(() => {
+    context = getMockContext();
+  });
+
+  teardown(() => {
+    for (const subscription of context.subscriptions) {
+      (subscription as vscode.Disposable | undefined)?.dispose?.();
+    }
+    cleanupMockContext(context);
+  });
+
+  test("formatProgressBar should render a clamped block bar with a percentage", () => {
+    assert.strictEqual(formatProgressBar(0, 4), "▱▱▱▱ 0%");
+    assert.strictEqual(formatProgressBar(1, 4), "▰▰▰▰ 100%");
+    assert.strictEqual(formatProgressBar(0.5, 4), "▰▰▱▱ 50%");
+    // Out-of-range ratios are clamped rather than producing garbage
+    assert.strictEqual(formatProgressBar(-1, 4), "▱▱▱▱ 0%");
+    assert.strictEqual(formatProgressBar(2, 4), "▰▰▰▰ 100%");
+  });
+
+  test("buildMenuItems should always lead with the View/Settings actions", () => {
+    const data: StatusBarData = {
+      available: true,
+      unlockedCount: 3,
+      totalCount: 10,
+      totalExp: 150,
+      closest: { title: "Creator 1", ratio: 0.5 },
+      latest: { title: "Code Monkey 1", achievedAt: new Date("2026-01-01") },
+    };
+
+    const items = buildMenuItems(data);
+    assert.strictEqual(items[0].action, "view");
+    assert.strictEqual(items[1].action, "settings");
+    assert.strictEqual(items[2].kind, vscode.QuickPickItemKind.Separator);
+
+    const labels = items.map((item) => item.label);
+    assert.ok(labels.some((label) => label.includes("3/10")));
+    assert.ok(labels.some((label) => label.includes("150 XP")));
+    assert.ok(labels.some((label) => label.includes("Creator 1")));
+    assert.ok(labels.some((label) => label.includes("Code Monkey 1")));
+  });
+
+  test("buildMenuItems should fall back to friendly placeholders when data is missing", () => {
+    const data: StatusBarData = {
+      available: true,
+      unlockedCount: 0,
+      totalCount: 0,
+      totalExp: 0,
+    };
+
+    const items = buildMenuItems(data);
+    const labels = items.map((item) => item.label);
+    assert.ok(labels.some((label) => label.includes("No achievement currently in progress")));
+    assert.ok(labels.some((label) => label.includes("No achievements unlocked yet")));
+  });
+
+  test("buildMenuItems should show a single unavailable notice when data could not be gathered", () => {
+    const data: StatusBarData = {
+      available: false,
+      unlockedCount: 0,
+      totalCount: 0,
+      totalExp: 0,
+    };
+
+    const items = buildMenuItems(data);
+    const labels = items.map((item) => item.label);
+    assert.ok(labels.some((label) => label.includes("unavailable")));
+    // Only the two actions plus the header plus the single notice
+    assert.strictEqual(items.length, 4);
+  });
+
+  test("gatherStatusBarData should reflect the current achievement/progression state", async () => {
+    const dbPath = path.join(context.globalStorageUri.fsPath, "test.sqlite");
+    db_lock._resetState();
+    db_model._resetState();
+    await db_model.activate(context, dbPath);
+
+    try {
+      const data = await gatherStatusBarData();
+      assert.strictEqual(data.available, true);
+      assert.ok(data.totalCount > 0);
+      assert.strictEqual(data.unlockedCount, 0);
+      assert.strictEqual(data.totalExp, 0);
+      assert.ok(data.closest);
+      assert.strictEqual(data.latest, undefined);
+    } finally {
+      await db_model.deactivate();
+    }
+  });
+
+  test("gatherStatusBarData should degrade gracefully when the database is unavailable", async () => {
+    db_lock._resetState();
+    db_model._resetState();
+
+    const data = await gatherStatusBarData();
+    assert.strictEqual(data.available, false);
+    assert.strictEqual(data.totalCount, 0);
+    assert.strictEqual(data.unlockedCount, 0);
+    assert.strictEqual(data.totalExp, 0);
+    assert.strictEqual(data.closest, undefined);
+    assert.strictEqual(data.latest, undefined);
+  });
+
+  test("registerAchievementsStatusBar should create a star status bar item wired to the toggle command", () => {
+    registerAchievementsStatusBar(context);
+
+    const item = context.subscriptions.find(
+      (s: any) => s && typeof s.text === "string" && s.text === "$(star-full)",
+    ) as vscode.StatusBarItem | undefined;
+
+    assert.ok(item, "star status bar item should be registered");
+    assert.strictEqual(item?.command, STATUS_BAR_MENU_COMMAND);
+  });
+
+  test("the toggle command should open and close the menu without throwing", async () => {
+    registerAchievementsStatusBar(context);
+
+    await vscode.commands.executeCommand(STATUS_BAR_MENU_COMMAND);
+    await vscode.commands.executeCommand(STATUS_BAR_MENU_COMMAND);
+  });
+});

--- a/src/views/statusbar.ts
+++ b/src/views/statusbar.ts
@@ -1,0 +1,212 @@
+/**
+ * Status bar entry point for the Achievements extension: a persistent
+ * star icon that pops up a quick-glance progress menu on click.
+ *
+ * @author BoxBoxJason
+ */
+
+import * as vscode from "vscode";
+import { AchievementController } from "../database/controller/achievements";
+import { ProgressionController } from "../database/controller/progressions";
+import Achievement from "../database/model/tables/Achievement";
+import { constants } from "../constants";
+import logger from "../utils/logger";
+
+export const STATUS_BAR_MENU_COMMAND = "achievements.statusBarMenu";
+
+// ==================== TYPES ====================
+export interface StatusBarData {
+  available: boolean;
+  unlockedCount: number;
+  totalCount: number;
+  totalExp: number;
+  closest?: { title: string; ratio: number };
+  latest?: { title: string; achievedAt: Date | undefined };
+}
+
+interface AchievementsMenuItem extends vscode.QuickPickItem {
+  action?: "view" | "settings";
+}
+
+// A re-click on the status bar item while the menu is open first fires the
+// QuickPick's blur/hide, then the command itself — so without this window
+// the menu would immediately reopen instead of staying closed.
+const RECLOSE_WINDOW_MS = 200;
+
+/**
+ * Formats a ratio (0-1) as a block-character progress bar with a trailing
+ * percentage. QuickPick has no graphical progress widget, so this is the
+ * text approximation used throughout the menu.
+ *
+ * @param {number} ratio - The completion ratio, between 0 and 1
+ * @param {number} width - The number of characters in the bar
+ * @returns {string} - The formatted progress bar
+ */
+export function formatProgressBar(ratio: number, width = 10): string {
+  const clamped = Math.min(1, Math.max(0, ratio));
+  const filled = Math.round(clamped * width);
+  const bar = "▰".repeat(filled) + "▱".repeat(width - filled);
+  return `${bar} ${Math.round(clamped * 100)}%`;
+}
+
+/**
+ * Gathers the data displayed in the status bar menu. Never throws: if the
+ * database isn't available (extension disabled, read-only lock, etc.) the
+ * returned data has `available: false` so the menu can degrade gracefully.
+ *
+ * @returns {Promise<StatusBarData>} - The status bar menu data
+ */
+export async function gatherStatusBarData(): Promise<StatusBarData> {
+  try {
+    const [
+      { totalAchievements, achievedCount },
+      progressions,
+      closest,
+      latest,
+    ] = await Promise.all([
+      Achievement.getAchievementStats(),
+      ProgressionController.getProgressions(),
+      AchievementController.getClosestAchievableAchievement(),
+      AchievementController.getLatestAchievedAchievement(),
+    ]);
+
+    return {
+      available: true,
+      unlockedCount: achievedCount,
+      totalCount: totalAchievements,
+      totalExp: Number(progressions[constants.criteria.EXP]) || 0,
+      closest: closest
+        ? { title: closest.achievement.title, ratio: closest.ratio }
+        : undefined,
+      latest: latest
+        ? { title: latest.title, achievedAt: latest.achievedAt }
+        : undefined,
+    };
+  } catch (error) {
+    logger.error("Failed to gather status bar data: " + String(error));
+    return {
+      available: false,
+      unlockedCount: 0,
+      totalCount: 0,
+      totalExp: 0,
+    };
+  }
+}
+
+/**
+ * Builds the QuickPick items for the status bar menu from already-gathered
+ * data, in display order: actions first, then a progress overview.
+ *
+ * @param {StatusBarData} data - The status bar menu data
+ * @returns {AchievementsMenuItem[]} - The QuickPick items to display
+ */
+export function buildMenuItems(data: StatusBarData): AchievementsMenuItem[] {
+  const items: AchievementsMenuItem[] = [
+    { label: "$(star-full) View Achievements", action: "view" },
+    { label: "$(gear) Settings", action: "settings" },
+    { label: "Progress", kind: vscode.QuickPickItemKind.Separator },
+  ];
+
+  if (!data.available) {
+    items.push({
+      label: "$(warning) Achievement tracking is disabled or unavailable",
+    });
+    return items;
+  }
+
+  items.push(
+    {
+      label: `$(check-all) ${data.unlockedCount}/${data.totalCount} achievements unlocked  ${formatProgressBar(
+        data.totalCount === 0 ? 1 : data.unlockedCount / data.totalCount,
+      )}`,
+    },
+    {
+      label: `$(zap) ${data.totalExp} XP`,
+    },
+    {
+      label: "Unlocking soon",
+      kind: vscode.QuickPickItemKind.Separator,
+    },
+    {
+      label: data.closest
+        ? `$(target) ${data.closest.title}  ${formatProgressBar(data.closest.ratio)}`
+        : "$(target) No achievement currently in progress",
+    },
+    {
+      label: "Latest Achievement",
+      kind: vscode.QuickPickItemKind.Separator,
+    },
+    {
+      label: data.latest
+        ? `$(sparkle) ${data.latest.title}${
+            data.latest.achievedAt
+              ? ` — ${data.latest.achievedAt.toLocaleDateString()}`
+              : ""
+          }`
+        : "$(sparkle) No achievements unlocked yet",
+    },
+  );
+
+  return items;
+}
+
+/**
+ * Registers the status bar item and the command that toggles its quick
+ * menu open/closed.
+ *
+ * @param {vscode.ExtensionContext} context - The extension context
+ * @returns {void}
+ */
+export function registerAchievementsStatusBar(
+  context: vscode.ExtensionContext,
+): void {
+  let quickPick: vscode.QuickPick<AchievementsMenuItem> | undefined;
+  let lastHideTime = 0;
+
+  const toggleCommand = vscode.commands.registerCommand(
+    STATUS_BAR_MENU_COMMAND,
+    async () => {
+      if (quickPick) {
+        quickPick.hide();
+        return;
+      }
+      if (Date.now() - lastHideTime < RECLOSE_WINDOW_MS) {
+        return;
+      }
+
+      const data = await gatherStatusBarData();
+      const qp = vscode.window.createQuickPick<AchievementsMenuItem>();
+      qp.items = buildMenuItems(data);
+      qp.placeholder = "Achievements";
+
+      qp.onDidAccept(() => {
+        const [selected] = qp.selectedItems;
+        qp.hide();
+        if (selected?.action === "view") {
+          vscode.commands.executeCommand("achievements.show");
+        } else if (selected?.action === "settings") {
+          vscode.commands.executeCommand("achievements.settings");
+        }
+      });
+      qp.onDidHide(() => {
+        lastHideTime = Date.now();
+        quickPick = undefined;
+        qp.dispose();
+      });
+
+      quickPick = qp;
+      qp.show();
+    },
+  );
+  context.subscriptions.push(toggleCommand);
+
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  statusBarItem.text = "$(star-full)";
+  statusBarItem.tooltip = "Achievements";
+  statusBarItem.command = STATUS_BAR_MENU_COMMAND;
+  statusBarItem.show();
+  context.subscriptions.push(statusBarItem);
+}


### PR DESCRIPTION
This PR adds a status bar item for the achievements extension and makes it open a newly created menu. The menu displays quick actions (open webview and go to settings), and a summary of recent activity:
1. Total achievements progress (how many achievements are achieved)
2. Total experience points gained
3. Closest achievement to obtain
4. Latest achievement obtained

Closes #101 